### PR TITLE
Add Kubernetes support

### DIFF
--- a/kubernetes/comment-deployment.yml
+++ b/kubernetes/comment-deployment.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: comment-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: comment
+  template:
+    metadata:
+      name: comment
+      labels:
+        app: comment
+    spec:
+      containers:
+      - image: jugatsu/comment
+        name: comment

--- a/kubernetes/mongo-deployment.yml
+++ b/kubernetes/mongo-deployment.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: mongo-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo
+  template:
+    metadata:
+      name: mongo
+      labels:
+        app: mongo
+    spec:
+      containers:
+      - image: mongo
+        name: mongo

--- a/kubernetes/post-deployment.yml
+++ b/kubernetes/post-deployment.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: post-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: post
+  template:
+    metadata:
+      name: post
+      labels:
+        app: post
+    spec:
+      containers:
+      - image: jugatsu/post
+        name: post

--- a/kubernetes/ui-deployment.yml
+++ b/kubernetes/ui-deployment.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: ui-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ui
+  template:
+    metadata:
+      name: ui
+      labels:
+        app: ui
+    spec:
+      containers:
+      - image: jugatsu/ui
+        name: ui


### PR DESCRIPTION
PR к ДЗ №28

1. Добавил начальную конфигурацию микросервисов в Kubernetes кластере:

- `post-deployment.yml` для развёртывания `post`

- `comment-deployment.yml` для развёртывания `comment`

- `ui-deployment.yml` для развёртывания `ui`

- `mongo-deployment.yml` для развёртывания MongoDB

Продеплоил данные манифесты на тестовом кластере, созданном по туториалу [Kubernetes The Hard Way](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/README.md).

Результат см. ниже:

![2017-11-27 23 14 26](https://user-images.githubusercontent.com/2243323/33288784-79bafe64-d3ce-11e7-8416-f12a0ed2a947.png)

----

2. Весь туториал Kubernates The Hard Way полностью автоматизировал при помощи ansible. Результат этой работы опубликовал в отдельном проекте https://github.com/jugatsu/kubernates-the-hard-way-using-only-ansible
> Только ансибл. Никаких баш скриптов

3. Плейбуки и роли полностью идемпотентные (за исключением правил создания файрвола в GCE)

4. Скриншот выше после деплоя приложения на кластер, созданном при помощи ansible :)

Closes #15 